### PR TITLE
Add favicon and title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@
 # you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
-title: Recast.AI Doc
+title: Recast.AI Docs
 email: services@recast.ai
 description: >- # this means to ignore newlines until "baseurl:"
   Find out our latest NLU, UX, DevOps and business news on our blog.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,5 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   <link href="https://unpkg.com/ionicons@4.1.2/dist/css/ionicons.min.css" rel="stylesheet">
-  <link href="https://cdn.recast.ai/website/deps/flag-icon.min.css" rel="stylesheet" type="text/css"/>
+  <link href="https://cdn.recast.ai/website/deps/flag-icon.min.css" rel="stylesheet" type="text/css" />
+  <link href="https://cdn.recast.ai/website/favicon/favicon-32.ico" rel="icon" type="image/x-icon">
+  <title>{{ site.title }}</title>
 </head>


### PR DESCRIPTION
### The title and the favicon was missing from the docs website:

<img width="383" alt="screen shot 2018-10-17 at 21 18 50" src="https://user-images.githubusercontent.com/5436545/47110876-44e7e700-d252-11e8-8b50-11e742462ac8.png">

### Fixed! 🎨

<img width="385" alt="screen shot 2018-10-17 at 21 18 38" src="https://user-images.githubusercontent.com/5436545/47110877-44e7e700-d252-11e8-9f24-b1870d779d91.png">
